### PR TITLE
feat: add support for `~/.scrappy.toml` config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ or
 scrappy --a <YOUR_API_KEY>
 ```
 
+### Config
+
+To set default options and arguments, you can create a `.scrappy.toml` file in your home directory `/~` with the following config options:
+
+```
+url = "some_url"
+inputFile = "some_input_file"
+outputFile = "some_output_file"
+tokenUsage = true | false
+stream = true | false
+```
+
 ## Features
 
 - **Input**: The main feature is that you can convert any website into a md, For this we will need a url of the page. You can provide a URL either using a file or command line arg.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ scrappy --a <YOUR_API_KEY>
 
 ### Config
 
-To set default options and arguments, you can create a `.scrappy.toml` file in your home directory `/~` with the following config options:
+To set default options and arguments, you can create a `.scrappy.toml` file in your home directory `~/` with the following config options:
 
 ```
 url = "some_url"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "groq-sdk": "^0.7.0"
+        "groq-sdk": "^0.7.0",
+        "smol-toml": "^1.3.0"
       },
       "bin": {
         "scrappy": "src/args/command.js"
@@ -209,6 +210,18 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.0.tgz",
+      "integrity": "sha512-tWpi2TsODPScmi48b/OQZGi2lgUmBCHy6SZrhi/FdnnHiU1GwebbCfuQuxsC3nHaLwtYeJGPrDZDIeodDOc4pA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "groq-sdk": "^0.7.0"
+    "groq-sdk": "^0.7.0",
+    "smol-toml": "^1.3.0"
   }
 }

--- a/src/args/command.js
+++ b/src/args/command.js
@@ -3,7 +3,7 @@ import fs from "fs";
 import { validateArgs, getUrlBody, convertIntoMd, saveMd } from "./helper.js";
 
 // Check if both input and output file names are provided
-let state = validateArgs(process.argv);
+let state = await validateArgs(process.argv);
 if (!state) {
   process.exit(1);
 }

--- a/src/args/helper.js
+++ b/src/args/helper.js
@@ -47,7 +47,7 @@ export async function validateArgs(args) {
     const configFilePath = path.join(os.homedir(), ".scrappy.toml");
     configOptions = await parseConfig(configFilePath);
   } catch (error) {
-    // If error thrown because config file not found, continue
+    // If file found but couldn't be parsed, exit
     if (error.code !== "ENOENT") {
       process.stderr.write(error.toString());
       process.exit(1);

--- a/src/args/helper.js
+++ b/src/args/helper.js
@@ -91,8 +91,8 @@ export async function validateArgs(args) {
   process.stdout.write("Validating the arguments... ");
 
   // Use URL CLI option if present
-  // If missing, use URL config option if present
   // If missing, use input file argument if present
+  // If missing, use URL config option if present
   // If missing, use input file config option if present
   // If missing, exit
   if (args.includes("--url") || args.includes("-u")) {
@@ -107,16 +107,20 @@ export async function validateArgs(args) {
       process.stderr.write("Please provide a valid url");
       process.exit(1);
     }
+    
     state.url = args[index + 1];
     state.isInputFile = false;
-  } else if (configOptions?.url) {
-    state.url = configOptions.url;
   } else {
     let [, , inputFile] = args; // Check if the input file is supplied as an argument
-    inputFile = inputFile || configOptions?.inputFile; // If not, try to get it from the config
     if (!inputFile) {
-      process.stderr.write("Please provide the input file");
-      process.exit(1);
+      if (configOptions?.url) {
+        state.url = configOptions.url;
+      } else if (configOptions?.inputFile) {
+        state.inputFile = configOptions.inputFile;
+      } else {
+        process.stderr.write("Please provide the input file");
+        process.exit(1);
+      }
     }
 
     // check if the input file exists


### PR DESCRIPTION
### Description

Fixes #8. Enables parsing of a config file at `~/.scrappy.toml` with support for the following keys:

- `url`
- `inputFile`
- `outputFile`
- `tokenUsage`
- `stream`

### Summary of Changes

1. Installed npm package [`smol-toml`](https://github.com/squirrelchat/smol-toml)
2. Added an async function `parseConfig(configFilePath)` to handle parsing the config file.

    ```js
    /**
     * Parses a TOML config file for options
     * @param {string} configFilePath Path to .toml config file
     * @returns {{ url: string | undefined, inputFile: string | undefined, outputFile: string | undefined, tokenUsage: boolean | undefined, stream: boolean | undefined }} An object containing the parsed options
     */
    export async function parseConfig(configFilePath) {
      const configfileContent = await fsP.readFile(configFilePath, {
        encoding: "utf8",
      });
      const configOptions = TOML.parse(configfileContent);
      return configOptions;
    }
    ```
3. Made `validateArgs()` an async function so it can call the above function. Added a try/catch around the call which catches parsing errors but lets the program continue if the file doesn't exist.
4. Modified argument/config parsing flow:
   1. Use URL CLI option if present
   2. if missing, use URL config option if present
   3. if missing, use input file argument if present
   4. if missing, use input file config option if present
   5. if missing, exit
5. Added comments explaining above flow
6. Added config section to README

### Notes

I used the module `fs:promises` in order to take advantage of async/await syntax, while the rest of the program uses `fs`. Let me know if you'd like this changed.